### PR TITLE
Fix macOS build

### DIFF
--- a/src/ArchFactory.h
+++ b/src/ArchFactory.h
@@ -19,7 +19,12 @@
 
 #pragma once
 
-#include "CL/cl.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
 #include "IArch.h"
 #include "ArchAMD.h"
 #include "ArchNVD.h"

--- a/src/DeviceOCL.h
+++ b/src/DeviceOCL.h
@@ -33,7 +33,12 @@
 #pragma once
 
 #include <string>
-#include "CL/cl.h"
+
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
 #include "IArch.h"
 #include "UtilOCL.h"

--- a/src/EnqueueInfoOCL.h
+++ b/src/EnqueueInfoOCL.h
@@ -20,7 +20,13 @@
 #pragma once
 #include "latke_config.h"
 #ifdef OPENCL_FOUND
-#include "CL/cl.h"
+
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
 #include "QueueOCL.h"
 
 

--- a/src/UtilOCL.cpp
+++ b/src/UtilOCL.cpp
@@ -36,7 +36,7 @@
 #include <windows.h>
 #else
 #include <sys/time.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <unistd.h>
 #endif
 

--- a/src/UtilOCL.h
+++ b/src/UtilOCL.h
@@ -32,10 +32,17 @@
 #pragma once
 #include "latke_config.h"
 #ifdef OPENCL_FOUND
-#include <CL/opencl.h>
 #include <string>
 #include <iostream>
-#include "CL/cl.h"
+
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#include <OpenCL/opencl.h>
+#else
+#include <CL/cl.h>
+#include <CL/opencl.h>
+#endif
+
 #include "IArch.h"
 
 namespace ltk {
@@ -284,51 +291,6 @@ static const char* getOpenCLErrorCodeStr(T input) {
 		return "CL_INVALID_KERNEL_DEFINITION";
 	case CL_INVALID_KERNEL:
 		return "CL_INVALID_KERNEL";
-	case CL_INVALID_ARG_INDEX:
-		return "CL_INVALID_ARG_INDEX";
-	case CL_INVALID_ARG_VALUE:
-		return "CL_INVALID_ARG_VALUE";
-	case CL_INVALID_ARG_SIZE:
-		return "CL_INVALID_ARG_SIZE";
-	case CL_INVALID_KERNEL_ARGS:
-		return "CL_INVALID_KERNEL_ARGS";
-	case CL_INVALID_WORK_DIMENSION:
-		return "CL_INVALID_WORK_DIMENSION";
-	case CL_INVALID_WORK_GROUP_SIZE:
-		return "CL_INVALID_WORK_GROUP_SIZE";
-	case CL_INVALID_WORK_ITEM_SIZE:
-		return "CL_INVALID_WORK_ITEM_SIZE";
-	case CL_INVALID_GLOBAL_OFFSET:
-		return "CL_INVALID_GLOBAL_OFFSET";
-	case CL_INVALID_EVENT_WAIT_LIST:
-		return "CL_INVALID_EVENT_WAIT_LIST";
-	case CL_INVALID_EVENT:
-		return "CL_INVALID_EVENT";
-	case CL_INVALID_OPERATION:
-		return "CL_INVALID_OPERATION";
-	case CL_INVALID_GL_OBJECT:
-		return "CL_INVALID_GL_OBJECT";
-	case CL_INVALID_BUFFER_SIZE:
-		return "CL_INVALID_BUFFER_SIZE";
-	case CL_INVALID_MIP_LEVEL:
-		return "CL_INVALID_MIP_LEVEL";
-	case CL_INVALID_GLOBAL_WORK_SIZE:
-		return "CL_INVALID_GLOBAL_WORK_SIZE";
-	case CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR:
-		return "CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR";
-	case CL_PLATFORM_NOT_FOUND_KHR:
-		return "CL_PLATFORM_NOT_FOUND_KHR";
-		//case CL_INVALID_PROPERTY_EXT:
-		//    return "CL_INVALID_PROPERTY_EXT";
-	case CL_DEVICE_PARTITION_FAILED_EXT:
-		return "CL_DEVICE_PARTITION_FAILED_EXT";
-	case CL_INVALID_PARTITION_COUNT_EXT:
-		return "CL_INVALID_PARTITION_COUNT_EXT";
-	case CL_INVALID_DEVICE_QUEUE:
-		return "CL_INVALID_DEVICE_QUEUE";
-	case CL_INVALID_PIPE_SIZE:
-		return "CL_INVALID_PIPE_SIZE";
-
 	default:
 		return "unknown error code";
 	}

--- a/src/platform.h
+++ b/src/platform.h
@@ -19,7 +19,13 @@
 
 #pragma once
 #ifdef OPENCL_FOUND
+
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
+#endif
+
 #include <string>
 #include "DeviceOCL.h"
 

--- a/tests/debayer/debayer.cpp
+++ b/tests/debayer/debayer.cpp
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include "common.h"
+#include <cmath>
 
 // template struct to handle debayer to either image or buffer
 template<typename M, typename A> struct Debayer {


### PR DESCRIPTION
On macOS the OpenCL header are located in `OpenCL/` instead of `CL/`.

Signed-off-by: Marcus Edel <marcus.edel@collabora.com>